### PR TITLE
Create ceph-swift.js

### DIFF
--- a/lib/ceph-swift.js
+++ b/lib/ceph-swift.js
@@ -438,6 +438,7 @@ Swift.prototype.retrieveAccountMetadata = function(callback) {
 Swift.prototype.uploadObject = function (container, local, remote, meta, callback){
   if (typeof meta === 'function'){
     callback = meta;
+    meta = {};
   }
   var md5="", data, value, headerKey, headers = {};
   for( var key in meta){


### PR DESCRIPTION
when call this method with four parameters:
client.uploadObject(containerName, fileBuffer, filename, function(err, res) {})

error occurred:  "TypeError: The header content contains invalid characters"